### PR TITLE
[add/style]:댓글 쓰기 버튼 추가

### DIFF
--- a/client/src/components/button/CommentBtn.jsx
+++ b/client/src/components/button/CommentBtn.jsx
@@ -1,0 +1,9 @@
+import { CommentButton } from "../../components/button/CommentBtn.styled"
+
+export default function CommentBtn() {
+  return (
+    <CommentButton>
+      댓글쓰기
+    </CommentButton>
+  )
+}

--- a/client/src/components/button/CommentBtn.styled.jsx
+++ b/client/src/components/button/CommentBtn.styled.jsx
@@ -1,0 +1,21 @@
+import tw from "tailwind-styled-components";
+
+export const ButtonSm = tw.button`
+  text-xs
+  rounded-full
+  px-3
+  py-1
+  transition duration-300 ease-in-out
+  max-md:text-[0.65rem]
+  max-md:px-2
+  max-md:py-px
+`;
+
+export const CommentButton = tw(ButtonSm)`
+  text-[#797979]
+  bg-white
+  border-solid
+  border-2
+  border-[#DCDCDC]
+  hover:text-black
+`


### PR DESCRIPTION
## 댓글 쓰기 버튼 추가 및 스타일 작업 (기능 x)

- [x] 댓글 쓰기 버튼(hover)
- basic: 배경: text-white, 폰트 색상: gray900, 테두리: gray500
- hover시 폰트 색상, 테두리 변경 - hover: 폰트 색상: text-black, 테두리: gray500 
- `button` 폴더 참고하기
- 
![스크린샷 2023-06-19 오전 11 53 41](https://github.com/codestates-seb/seb44_pre_015/assets/109754988/6d2a1a07-c61b-4f6a-8c57-3f317c37076a)